### PR TITLE
Indicate added VCS lines with a green plus

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -453,7 +453,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
     call s:HL("CursorColumn", "", s:cursorcolumn, "none")
     call s:HL("PMenu", s:foreground, s:selection, "none")
     call s:HL("PMenuSel", s:foreground, s:selection, "reverse")
-    call s:HL("SignColumn", "", s:background, "none")
+    call s:HL("SignColumn", s:green, s:background, "none")
   end
   if version >= 703
     call s:HL("ColorColumn", "", s:cursorcolumn, "none")


### PR DESCRIPTION
Using a green plus is a standard convention for colored diffs, and
makes the change stand out more than just having the plus as the same
color as that of standard text.