### PR TITLE
Ninrod's dotfiles vim+tmux+zsh config is using papercolor light.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Suggestions/Wishes/Questions/Comments are welcome via [Github issues](https://gi
 
 [Airline PaperColor Theme for Emacs Powerline](https://github.com/AnthonyDiGirolamo/airline-themes) by Anthony DiGirolamo
 
-[Airline PaperColor Theme for Vim Lightline](https://github.com/itchyny/lightline.vim) 
+[Airline PaperColor Theme for Vim Lightline](https://github.com/itchyny/lightline.vim)
 
+[Ninrod's `vim + tmux + zsh` dotfiles](github.com/ninrod/dotfiles.git) by [Filipe Silva](https://github.com/ninrod)
 
 Feel free to add related projects here!


### PR DESCRIPTION
@NLKNguyen, I liked your theme so much that I've had it integrated into my full vim+tmux+zsh configuration. Thank you. Check it out [here][1].

![screenshot-vi-tmux](https://raw.githubusercontent.com/ninrod/mac-shell-config/misc/images/papercolor-screenshot.png)

[1]: <http://github.com/ninrod/dotfiles>

