### PR TITLE
New airline colorscheme based on lucius airline theme's implementation

### DIFF
--- a/autoload/airline/themes/PaperColor.vim
+++ b/autoload/airline/themes/PaperColor.vim
@@ -1,133 +1,56 @@
 let g:airline#themes#PaperColor#palette = {}
 
-let s:is_dark=(&background == 'dark')
+function! airline#themes#PaperColor#refresh()
 
-if s:is_dark " DARK VARIANT
-  let g:airline#themes#PaperColor#palette.accents = {
-        \ 'red': [ '#66d9ef' , '' , 81 , '' , '' ],
-        \ }
+    let s:N1 = airline#themes#get_highlight('StatusLine')
+    let s:N2 = airline#themes#get_highlight('Folded')
+    let s:N3 = airline#themes#get_highlight('CursorLine')
+    let g:airline#themes#PaperColor#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
 
-  " Normal Mode:
-  let s:N1 = [ '#585858' , '#e4e4e4' , 235 , 37 ] " Mode
-  let s:N2 = [ '#e4e4e4' , '#0087af' , 251 , 240  ] " Info
-  let s:N3 = [ '#eeeeee' , '#005f87' , 251 , 237  ] " StatusLine
+    let modified_group = airline#themes#get_highlight('Statement')
+    let g:airline#themes#PaperColor#palette.normal_modified = {
+                \ 'airline_c': [modified_group[0], '', modified_group[2], '', '']
+                \ }
 
+    let warning_group = airline#themes#get_highlight('DiffDelete')
+    let g:airline#themes#PaperColor#palette.normal.airline_warning = warning_group
+    let g:airline#themes#PaperColor#palette.normal_modified.airline_warning = warning_group
 
-  let g:airline#themes#PaperColor#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-  let g:airline#themes#PaperColor#palette.normal_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 251 , 237 , '' ] ,
-        \ }
+    let s:I1 = airline#themes#get_highlight('DiffAdd')
+    let s:I2 = s:N2
+    let s:I3 = s:N3
+    let g:airline#themes#PaperColor#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+    let g:airline#themes#PaperColor#palette.insert_modified = g:airline#themes#PaperColor#palette.normal_modified
+    let g:airline#themes#PaperColor#palette.insert.airline_warning = g:airline#themes#PaperColor#palette.normal.airline_warning
+    let g:airline#themes#PaperColor#palette.insert_modified.airline_warning = g:airline#themes#PaperColor#palette.normal_modified.airline_warning
 
+    let s:R1 = airline#themes#get_highlight('DiffChange')
+    let s:R2 = s:N2
+    let s:R3 = s:N3
+    let g:airline#themes#PaperColor#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+    let g:airline#themes#PaperColor#palette.replace_modified = g:airline#themes#PaperColor#palette.normal_modified
+    let g:airline#themes#PaperColor#palette.replace.airline_warning = g:airline#themes#PaperColor#palette.normal.airline_warning
+    let g:airline#themes#PaperColor#palette.replace_modified.airline_warning = g:airline#themes#PaperColor#palette.normal_modified.airline_warning
 
-  " Insert Mode:
-  let s:I1 = [ '#585858' , '#e4e4e4' , 235 , 37 ] " Mode
-  let s:I2 = [ '#e4e4e4' , '#0087af' , 251 , 240 ] " Info
-  let s:I3 = [ '#eeeeee' , '#005f87' , 251 , 237 ] " StatusLine
+    let s:V1 = airline#themes#get_highlight('Cursor')
+    let s:V2 = s:N2
+    let s:V3 = s:N3
+    let g:airline#themes#PaperColor#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
+    let g:airline#themes#PaperColor#palette.visual_modified = g:airline#themes#PaperColor#palette.normal_modified
+    let g:airline#themes#PaperColor#palette.visual.airline_warning = g:airline#themes#PaperColor#palette.normal.airline_warning
+    let g:airline#themes#PaperColor#palette.visual_modified.airline_warning = g:airline#themes#PaperColor#palette.normal_modified.airline_warning
 
+    let s:IA = airline#themes#get_highlight('StatusLineNC')
+    let g:airline#themes#PaperColor#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+    let g:airline#themes#PaperColor#palette.inactive_modified = {
+                \ 'airline_c': [ modified_group[0], '', modified_group[2], '', '' ]
+                \ }
 
-  let g:airline#themes#PaperColor#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
-  let g:airline#themes#PaperColor#palette.insert_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 251 , 237 , '' ] ,
-        \ }
+    let g:airline#themes#PaperColor#palette.accents = {
+                \ 'red': airline#themes#get_highlight('Constant'),
+                \ }
 
+endfunction
 
-  " Replace Mode:
-  let g:airline#themes#PaperColor#palette.replace = copy(g:airline#themes#PaperColor#palette.insert)
-  let g:airline#themes#PaperColor#palette.replace.airline_a = [ '#d7005f'   , '#e4e4e4' , 22 , 37, ''     ]
-  let g:airline#themes#PaperColor#palette.replace_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 251 , 237 , '' ] ,
-        \ }
+call airline#themes#PaperColor#refresh()
 
-
-  " Visual Mode:
-  let s:V1 = [ '#005f87', '#e4e4e4', 235,  37 ]
-  let s:V2 = [ '',        '#0087af', '',  240  ]
-  let s:V3 = [ '#e4e4e4', '#005f87', 251, 237  ]
-
-  let g:airline#themes#PaperColor#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
-  let g:airline#themes#PaperColor#palette.visual_modified = {
-        \ 'airline_c': [ '#e4e4e4', '#005f87', 254, 237 ] ,
-        \ }
-
-  " Inactive:
-  let s:IA = [ '#585858' , '#e4e4e4' , 251 , 237 , '' ]
-  let g:airline#themes#PaperColor#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
-  let g:airline#themes#PaperColor#palette.inactive_modified = {
-        \ 'airline_c': [ '#585858' , '#e4e4e4' , 240 , 254 , '' ] ,
-        \ }
-
-
-  " CtrlP:
-  if !get(g:, 'loaded_ctrlp', 0)
-    finish
-  endif
-  let g:airline#themes#PaperColor#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
-        \ [ '#e4e4e4' , '#005f87' , 254 , 237  , ''     ] ,
-        \ [ '#e4e4e4' , '#0087af' , 254 , 240  , ''     ] ,
-        \ [ '#585858' , '#e4e4e4' , 235 , 37 , 'bold' ] )
-
-else
-  let g:airline#themes#PaperColor#palette.accents = {
-        \ 'red': [ '#66d9ef' , '' , 81 , '' , '' ],
-        \ }
-
-  " Normal Mode:
-  let s:N1 = [ '#585858' , '#e4e4e4' , 240 , 254 ] " Mode
-  let s:N2 = [ '#e4e4e4' , '#0087af' , 254 , 31  ] " Info
-  let s:N3 = [ '#eeeeee' , '#005f87' , 255 , 24  ] " StatusLine
-
-
-  let g:airline#themes#PaperColor#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-  let g:airline#themes#PaperColor#palette.normal_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 255 , 24 , '' ] ,
-        \ }
-
-
-  " Insert Mode:
-  let s:I1 = [ '#585858' , '#e4e4e4' , 240 , 254 ] " Mode
-  let s:I2 = [ '#e4e4e4' , '#0087af' , 254 , 31  ] " Info
-  let s:I3 = [ '#eeeeee' , '#005f87' , 255 , 24  ] " StatusLine
-
-
-  let g:airline#themes#PaperColor#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
-  let g:airline#themes#PaperColor#palette.insert_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 255 , 24 , '' ] ,
-        \ }
-
-
-  " Replace Mode:
-  let g:airline#themes#PaperColor#palette.replace = copy(g:airline#themes#PaperColor#palette.insert)
-  let g:airline#themes#PaperColor#palette.replace.airline_a = [ '#d7005f'   , '#e4e4e4' , 161 , 254, ''     ]
-  let g:airline#themes#PaperColor#palette.replace_modified = {
-        \ 'airline_c': [ '#eeeeee' , '#005f87' , 255 , 24 , '' ] ,
-        \ }
-
-
-  " Visual Mode:
-  let s:V1 = [ '#005f87', '#e4e4e4', 24,  254 ]
-  let s:V2 = [ '',        '#0087af', '',  31  ]
-  let s:V3 = [ '#e4e4e4', '#005f87', 254, 24  ]
-
-  let g:airline#themes#PaperColor#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
-  let g:airline#themes#PaperColor#palette.visual_modified = {
-        \ 'airline_c': [ '#e4e4e4', '#005f87', 254, 24  ] ,
-        \ }
-
-  " Inactive:
-  let s:IA = [ '#585858' , '#e4e4e4' , 240 , 254 , '' ]
-  let g:airline#themes#PaperColor#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
-  let g:airline#themes#PaperColor#palette.inactive_modified = {
-        \ 'airline_c': [ '#585858' , '#e4e4e4' , 240 , 254 , '' ] ,
-        \ }
-
-
-  " CtrlP:
-  if !get(g:, 'loaded_ctrlp', 0)
-    finish
-  endif
-  let g:airline#themes#PaperColor#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
-        \ [ '#e4e4e4' , '#005f87' , 254 , 24  , ''     ] ,
-        \ [ '#e4e4e4' , '#0087af' , 254 , 31  , ''     ] ,
-        \ [ '#585858' , '#e4e4e4' , 240 , 254 , 'bold' ] )
-
-endif


### PR DESCRIPTION
I looked at [lucius](https://github.com/jonathanfilip/vim-lucius) implementation of airline theme and found it did not hard code colors into it, instead it gets the current highlight by
`airline#themes#get_highlight('Statement')` I think this is a good practice and I just copy-pasted substituted lucius with PaperColor, and the result seems good, maybe we can either merge this or change the way we implement airline-themes?

Dark screenshot:
![screen shot 2016-02-17 at 6 12 31 pm](https://cloud.githubusercontent.com/assets/1317203/13128200/1be5d38a-d5a2-11e5-9fc4-0210a407f748.png)
 
![screen shot 2016-02-17 at 6 12 39 pm](https://cloud.githubusercontent.com/assets/1317203/13128202/1f0e4538-d5a2-11e5-8770-b9515f712057.png)

![screen shot 2016-02-17 at 6 12 52 pm](https://cloud.githubusercontent.com/assets/1317203/13128205/22701846-d5a2-11e5-8aa7-7ea488319b80.png)

Light screenshot:
![screen shot 2016-02-17 at 6 13 39 pm](https://cloud.githubusercontent.com/assets/1317203/13128217/3a73a16a-d5a2-11e5-9b6c-bf850d45422b.png)

![screen shot 2016-02-17 at 6 13 46 pm](https://cloud.githubusercontent.com/assets/1317203/13128219/3d088fda-d5a2-11e5-804a-22c174b1b9fd.png)

![screen shot 2016-02-17 at 6 13 55 pm](https://cloud.githubusercontent.com/assets/1317203/13128220/3ef5842e-d5a2-11e5-8fa7-f7b847e499b4.png)
