### PR TITLE
Add iTerm2 color scheme in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Suggestions/Wishes/Questions/Comments are welcome via [Github issues](https://gi
 
 [Terminal Theme](https://www.reddit.com/r/vim/comments/36xzbs/vim_paper_color_theme_inspired_by_googles/crqbfpa) by Fixles
 
+[PaperColor Light for iTerm2](https://github.com/aseom/dotfiles/blob/v2/iterm2/papercolor-light.itermcolors) by ASeom Han
+
 [PaperColor Theme for Vis Editor](https://github.com/jceb/dotfiles/blob/master/config/vis/lexers/themes/papercolor.lua) by Jan Christoph Ebersbach
 
 [Airline PaperColor Theme for Emacs Powerline](https://github.com/AnthonyDiGirolamo/airline-themes) by Anthony DiGirolamo

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Suggestions/Wishes/Questions/Comments are welcome via [Github issues](https://gi
 
 [Terminal Theme](https://www.reddit.com/r/vim/comments/36xzbs/vim_paper_color_theme_inspired_by_googles/crqbfpa) by Fixles
 
-[PaperColor Light for iTerm2](https://github.com/aseom/dotfiles/blob/v2/iterm2/papercolor-light.itermcolors) by ASeom Han
+[PaperColor Light for iTerm2](https://github.com/aseom/dotfiles/blob/v2/osx/iterm2/papercolor-light.itermcolors) by ASeom Han
 
 [PaperColor Theme for Vis Editor](https://github.com/jceb/dotfiles/blob/master/config/vis/lexers/themes/papercolor.lua) by Jan Christoph Ebersbach
 


### PR DESCRIPTION
![papercolor](https://cloud.githubusercontent.com/assets/16207504/15096871/114f2e48-1545-11e6-84ea-b9bc5268c003.png)

I was made iTerm2 color scheme based on [this reddit post](https://www.reddit.com/r/vim/comments/36xzbs/vim_paper_color_theme_inspired_by_googles/crqbfpa).
So i want add link for sharing my scheme.

Thank you :)