### PR TITLE
Airline theme is actually case sensitive.. updated README!

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ There are syntax highlighting enhancement plugins that improve upon Vim built-in
 
 To set [vim-airline](https://github.com/bling/vim-airline) theme:
 
-    let g:airline_theme='PaperColor'
+    let g:airline_theme='papercolor'
 
 To set [lightline](https://github.com/itchyny/lightline.vim) theme:
 


### PR DESCRIPTION
After trying to figure out why vim was complaining about "No PaperColor theme found!" I changed the setting to lowercase and it worked... updating the readme for the future users...