### PR TITLE
Cpp standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,21 @@ let g:PaperColor_Light_Override = { 'background' : '#abcdef', 'cursorline' : '#d
 #### Python
 
 ```VimL
-let g:PaperColor_Python_Highlight_Builtins = 1  " turns built-in highlighting on
+" highlight keywords for python language built-ins
+" examples: (print, iter, dir)
+let g:PaperColor_Python_Highlight_Builtins = 1
+```
+
+#### C / C++
+
+```VimL
+" highlight keywords from the C++ standard library
+" examples: (cin, cout, insert, first)
+let g:PaperColor_CPP_Highlight_Standard_Library = 1
+
+" highlight keywords for built-in functions in the C language
+" examples: (printf, bsearch, getenv)
+let g:PaperColor_C_Highlight_Builtins = 1
 ```
 
 ## Syntax Highlighting Plugins Target

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1008,6 +1008,8 @@ fun! s:set_highlightings_variable()
   call s:HL("cppSTLiterator", s:foreground, "", s:bold)
   call s:HL("cppSTLfunction",
         \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
+  call s:HL("cppSTLios",
+        \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
   call s:HL("cppExceptions", s:red, "", "")
   call s:HL("cppStatement", s:blue, "", "")
   call s:HL("cppStorageClass", s:navy, "", s:bold)

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -784,7 +784,7 @@ fun! s:cpp_highlight_standard_library(value_if_bool, default)
   return s:value_if_global_boolean_else_other(
         \'PaperColor_CPP_Highlight_Standard_Library',
         \a:value_if_bool,
-        \a:)
+        \a:default)
 endfun
 
 fun! s:c_highlight_builtins(value_if_bool, default)
@@ -792,7 +792,7 @@ fun! s:c_highlight_builtins(value_if_bool, default)
   return s:value_if_global_boolean_else_other(
         \'PaperColor_C_Highlight_Builtins',
         \a:value_if_bool,
-        \a:)
+        \a:default)
 endfun
 
 " }}}

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -788,7 +788,7 @@ fun! s:cpp_highlight_standard_library(value_if_bool, default)
 endfun
 
 fun! s:c_highlight_builtins(value_if_bool, default)
-  " g:PaperColor_CPP_Highlight_Standard_Library
+  " g:PaperColor_C_Highlight_Builtins
   return s:value_if_global_boolean_else_other(
         \'PaperColor_C_Highlight_Builtins',
         \a:value_if_bool,
@@ -996,9 +996,9 @@ fun! s:set_highlightings_variable()
   call s:HL("cppBoolean", s:navy, "", "")
   call s:HL("cppSTLnamespace", s:purple, "", "")
   call s:HL("cppSTLconstant",
-        \cpp_highlight_standard_library(s:green, s:foreground),
+        \s:cpp_highlight_standard_library(s:green, s:foreground),
         \"",
-        \cpp_highlight_standard_library(s:bold, ""))
+        \s:cpp_highlight_standard_library(s:bold, ""))
   call s:HL("cppSTLtype",
         \s:cpp_highlight_standard_library(s:pink, s:foreground),
         \"",

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -778,6 +778,13 @@ fun! s:python_highlight_builtins(color)
         \a:color)
 endfun
 
+fun! s:cpp_highlight_standard_library(color)
+  " g:PaperColor_Python_Highlight_Builtins
+  return s:color_if_global_boolean_else_foreground(
+        \'PaperColor_CPP_Highlight_Standard_Library',
+        \a:color)
+endfun
+
 " }}}
 
 " SET SYNTAX HIGHLIGHTING: {{{
@@ -979,7 +986,7 @@ fun! s:set_highlightings_variable()
   call s:HL("cppBoolean", s:navy, "", "")
   call s:HL("cppSTLnamespace", s:purple, "", "")
   call s:HL("cppSTLconstant", s:foreground, "", "")
-  call s:HL("cppSTLtype", s:foreground, "", "")
+  call s:HL("cppSTLtype", s:cpp_highlight_standard_library(s:pink), "", "")
   call s:HL("cppSTLexception", s:pink, "", "")
   call s:HL("cppSTLfunctional", s:foreground, "", s:bold)
   call s:HL("cppSTLiterator", s:foreground, "", s:bold)

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1007,9 +1007,11 @@ fun! s:set_highlightings_variable()
   call s:HL("cppSTLfunctional", s:foreground, "", s:bold)
   call s:HL("cppSTLiterator", s:foreground, "", s:bold)
   call s:HL("cppSTLfunction",
-        \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
+        \s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
   call s:HL("cppSTLios",
-        \ s:cpp_highlight_standard_library(s:green, s:foreground), "", "")
+        \s:cpp_highlight_standard_library(s:olive, s:foreground),
+        \"",
+        \s:cpp_highlight_standard_library(s:bold, ""))
   call s:HL("cppExceptions", s:red, "", "")
   call s:HL("cppStatement", s:blue, "", "")
   call s:HL("cppStorageClass", s:navy, "", s:bold)

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1009,7 +1009,7 @@ fun! s:set_highlightings_variable()
   call s:HL("cppSTLfunction",
         \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
   call s:HL("cppSTLios",
-        \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
+        \ s:cpp_highlight_standard_library(s:green, s:foreground), "", "")
   call s:HL("cppExceptions", s:red, "", "")
   call s:HL("cppStatement", s:blue, "", "")
   call s:HL("cppStorageClass", s:navy, "", s:bold)

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -784,7 +784,15 @@ fun! s:cpp_highlight_standard_library(value_if_bool, default)
   return s:value_if_global_boolean_else_other(
         \'PaperColor_CPP_Highlight_Standard_Library',
         \a:value_if_bool,
-        \a:default)
+        \a:)
+endfun
+
+fun! s:c_highlight_builtins(value_if_bool, default)
+  " g:PaperColor_CPP_Highlight_Standard_Library
+  return s:value_if_global_boolean_else_other(
+        \'PaperColor_C_Highlight_Builtins',
+        \a:value_if_bool,
+        \a:)
 endfun
 
 " }}}
@@ -976,7 +984,7 @@ fun! s:set_highlightings_variable()
   " call s:HL("cSemiColon","", s:blue, "")
   call s:HL("cOperator",s:aqua, "", "")
   " call s:HL("cStatement",s:pink, "", "")
-  call s:HL("cFunction", s:foreground, "", "")
+  call s:HL("cFunction", s:c_highlight_builtins(s:blue, s:foreground), "", "")
   " call s:HL("cTodo", s:comment, "", s:bold)
   " call s:HL("cStructure", s:blue, "", s:bold)
   call s:HL("cCustomParen", s:foreground, "", "")
@@ -987,7 +995,10 @@ fun! s:set_highlightings_variable()
   " CPP highlighting
   call s:HL("cppBoolean", s:navy, "", "")
   call s:HL("cppSTLnamespace", s:purple, "", "")
-  call s:HL("cppSTLconstant", s:foreground, "", "")
+  call s:HL("cppSTLconstant",
+        \cpp_highlight_standard_library(s:green, s:foreground),
+        \"",
+        \cpp_highlight_standard_library(s:bold, ""))
   call s:HL("cppSTLtype",
         \s:cpp_highlight_standard_library(s:pink, s:foreground),
         \"",
@@ -995,7 +1006,8 @@ fun! s:set_highlightings_variable()
   call s:HL("cppSTLexception", s:pink, "", "")
   call s:HL("cppSTLfunctional", s:foreground, "", s:bold)
   call s:HL("cppSTLiterator", s:foreground, "", s:bold)
-  " call s:HL("cppSTLfunction", s:aqua, "", s:bold)
+  call s:HL("cppSTLfunction",
+        \ s:cpp_highlight_standard_library(s:blue, s:foreground), "", "")
   call s:HL("cppExceptions", s:red, "", "")
   call s:HL("cppStatement", s:blue, "", "")
   call s:HL("cppStorageClass", s:navy, "", s:bold)

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -763,26 +763,28 @@ endfun
 
 " LANGUAGE SPECIFIC SYNTAX HIGHLIGHTING FUNCTIONS: {{{
 
-fun! s:color_if_global_boolean_else_foreground(g_bool, color)
+fun! s:value_if_global_boolean_else_other(g_bool, value_if_bool, default)
   if get(g:, a:g_bool, 0) ==# 1
-    return a:color
+    return a:value_if_bool
   else
-    return s:foreground
+    return a:default
   endif
 endfun
 
-fun! s:python_highlight_builtins(color)
+fun! s:python_highlight_builtins(value_if_bool, default)
   " g:PaperColor_Python_Highlight_Builtins
-  return s:color_if_global_boolean_else_foreground(
+  return s:value_if_global_boolean_else_other(
         \'PaperColor_Python_Highlight_Builtins',
-        \a:color)
+        \a:value_if_bool,
+        \a:default)
 endfun
 
-fun! s:cpp_highlight_standard_library(color)
-  " g:PaperColor_Python_Highlight_Builtins
-  return s:color_if_global_boolean_else_foreground(
+fun! s:cpp_highlight_standard_library(value_if_bool, default)
+  " g:PaperColor_CPP_Highlight_Standard_Library
+  return s:value_if_global_boolean_else_other(
         \'PaperColor_CPP_Highlight_Standard_Library',
-        \a:color)
+        \a:value_if_bool,
+        \a:default)
 endfun
 
 " }}}
@@ -986,7 +988,10 @@ fun! s:set_highlightings_variable()
   call s:HL("cppBoolean", s:navy, "", "")
   call s:HL("cppSTLnamespace", s:purple, "", "")
   call s:HL("cppSTLconstant", s:foreground, "", "")
-  call s:HL("cppSTLtype", s:cpp_highlight_standard_library(s:pink), "", "")
+  call s:HL("cppSTLtype",
+        \s:cpp_highlight_standard_library(s:pink, s:foreground),
+        \"",
+        \s:cpp_highlight_standard_library(s:bold, ""))
   call s:HL("cppSTLexception", s:pink, "", "")
   call s:HL("cppSTLfunctional", s:foreground, "", s:bold)
   call s:HL("cppSTLiterator", s:foreground, "", s:bold)
@@ -1162,8 +1167,10 @@ fun! s:set_highlightings_variable()
   call s:HL("pythonBytesEscape", s:olive, "", s:bold)
   call s:HL("pythonDottedName", s:purple, "", "")
   call s:HL("pythonStrFormat", s:foreground, "", "")
-  call s:HL("pythonBuiltinFunc", s:python_highlight_builtins(s:blue), "", "")
-  call s:HL("pythonBuiltinObj", s:python_highlight_builtins(s:red), "", "")
+  call s:HL("pythonBuiltinFunc",
+        \s:python_highlight_builtins(s:blue, s:foreground), "", "")
+  call s:HL("pythonBuiltinObj",
+        \s:python_highlight_builtins(s:red, s:foreground), "", "")
 
   " Java Highlighting
   call s:HL("javaExternal", s:pink, "", "")


### PR DESCRIPTION
# C builtins / C++ standard library syntax options

This pull request resembles:

https://github.com/NLKNguyen/papercolor-theme/pull/84

However, I've put some thought into highlighting options for the C++ standard library / C language builtins. I believe this option is especially important for C++ because the standard library is 2/3 of the written standard. As usual, this pull request provides users the option to override the default behavior of no builtin highlighting, keeping with PaperColor's philosophy.

## Change to global boolean evaluation function

In order to elegantly implement the syntax options for the standard library functions, I needed a way to impact both the "bold" flag and the syntax color. In order to achieve this elegantly, I changed the boolean flag function to take three values: 

```VimL
fun! s:value_if_global_boolean_else_other(g_bool, value_if_bool, default)
```

By generalizing the abstract function (eg, can choose your own default, not mentioning color specifically to enable using signals for thickness instead of color), I was able to use the derived functions to handle both color and boldness. As a result, I had to revise the functions used for Python builtins. However, to me, this makes the framework simpler and more extensible. Hopefully you agree!