### PR TITLE
Support jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ There are syntax highlighting enhancement plugins that improve upon Vim built-in
 
 * C: [c-syntax.vim](https://github.com/NLKNguyen/c-syntax.vim)
 * JavaScript: [vim-javascript](https://github.com/pangloss/vim-javascript)
+* Jsx: [vim-jsx-pretty](https://github.com/MaxMEllon/vim-jsx-pretty)
 * JSON: [vim-json](https://github.com/elzr/vim-json)
 * Go: [vim-go](https://github.com/fatih/vim-go)
 * DTrace: [dtrace-syntax-file](https://github.com/vim-scripts/dtrace-syntax-file)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Support True color / **GUI-color** and identical **256-color** that the design i
 
 Also gracefully support down to **16-color** terminal, which will use terminal native colors. You need to change the terminal colors to PaperColor palette.
 
-In 8-color and 4-color, it might lack the necessary variation of colors to express PaperColor, but seriously let me know if you still use these kinds of terminals. 
+In 8-color and 4-color, it might lack the necessary variation of colors to express PaperColor, but seriously let me know if you still use these kinds of terminals.
 
 
 ### Languages and Plugins
@@ -51,7 +51,7 @@ set background=light
 colorscheme PaperColor
 ```
 
-Or using the dark version: 
+Or using the dark version:
 
 ```VimL
 set background=dark
@@ -71,12 +71,12 @@ set laststatus=2
 
 ## User-config Options
 
-This theme currently provides theme options and language-specific options. All config options can be stored in global variable `g:PaperColor_Theme_Options` which can be set in your `.vimrc` 
+This theme currently provides theme options and language-specific options. All config options can be stored in global variable `g:PaperColor_Theme_Options` which can be set in your `.vimrc`
 
 
-**Note**: 
+**Note**:
 + This `g:PaperColor_Theme_Options` variable must be placed anywhere **before** `color PaperColor` command.
-+ if the same option is provided in both a theme and a theme's variant, the value in the theme's variant options will take precedence. 
++ if the same option is provided in both a theme and a theme's variant, the value in the theme's variant options will take precedence.
 
 ### Theme Options
 
@@ -114,7 +114,7 @@ The overriding setting is placed in `override` key of `g:PaperColor_Theme_Option
 ```VimL
 let g:PaperColor_Theme_Options = {
   \   'theme': {
-  \     'default.dark': { 
+  \     'default.dark': {
   \       'override' : {
   \         'color00' : ['#080808', '232'],
   \         'linenumber_bg' : ['#080808', '232']

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1609,6 +1609,19 @@ fun! s:apply_syntax_highlightings()
   exec 'hi jsBraces' . s:fg_blue
   exec 'hi jsNoise' . s:fg_blue
 
+  " Jsx Highlighting
+  " @target https://github.com/MaxMEllon/vim-jsx-pretty
+  exec 'hi jsxTagName' . s:fg_wine
+  exec 'hi jsxComponentName' . s:fg_wine
+  exec 'hi jsxAttrib' . s:fg_pink
+  exec 'hi jsxEqual' . s:fg_comment
+  exec 'hi jsxString' . s:fg_blue
+  exec 'hi jsxCloseTag' . s:fg_comment
+  exec 'hi jsxCloseString' . s:fg_comment
+  exec 'hi jsxDot' . s:fg_wine
+  exec 'hi jsxNamespace' . s:fg_wine
+  exec 'hi jsxPunct' . s:fg_comment
+
   " Json Highlighting
   " @target https://github.com/elzr/vim-json
   exec 'hi jsonKeyword' . s:fg_blue

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -207,7 +207,7 @@ endfun
 
 " Acquire Theme Data: {{{
 
-" Brief: 
+" Brief:
 "   Function to get theme information and store in variables for other
 "   functions to use
 "
@@ -219,13 +219,13 @@ endfun
 "   g:PaperColor_Theme_Options            <dictionary>  user options
 "
 " Expose:
-"   s:theme_name       <string>     the name of the selected theme 
+"   s:theme_name       <string>     the name of the selected theme
 "   s:selected_theme   <dictionary> the selected theme object (contains palette, etc.)
 "   s:selected_variant <string>     'light' or 'dark'
 "   s:palette          <dictionary> the palette of selected theme
 "   s:options          <dictionary> user options
 fun! s:acquire_theme_data()
-  
+
   " Get theme name: {{{
   let s:theme_name = 'default'
 
@@ -343,8 +343,8 @@ endfun
 fun! s:generate_theme_option_variables()
   " 0. All possible theme option names must be registered here
   let l:available_theme_options = [
-        \ 'allow_bold', 
-        \ 'allow_italic', 
+        \ 'allow_bold',
+        \ 'allow_italic',
         \ 'transparent_background',
         \ ]
 
@@ -382,7 +382,7 @@ fun! s:generate_theme_option_variables()
   if has_key(s:options, 'theme')
     let s:theme_options = s:options['theme']
   endif
-  
+
   " 3.1 In case user sets for a theme without specifying which variant
   if has_key(s:theme_options, s:theme_name)
     let l:theme_options = s:theme_options[s:theme_name]
@@ -394,7 +394,7 @@ fun! s:generate_theme_option_variables()
 
 
   " 3.2 In case user sets for a specific variant of a theme
-  
+
   " Create the string that the user might have set for this theme variant
   " for example, 'default.dark'
   let l:specific_theme_variant = s:theme_name . '.' . s:selected_variant
@@ -456,7 +456,7 @@ fun! s:set_overriding_colors()
       if !empty(s:themeOpt_override)
         call s:load_GUI_to_256_converter()
       endif
- 
+
       for l:color in keys(s:themeOpt_override)
         let l:value = s:themeOpt_override[l:color]
         if l:value[1] == ''
@@ -492,7 +492,7 @@ endfun
 " Expose:
 "   s:langOpt_[LANGUAGE]__[OPTION]  <any>   variables for language options
 "
-" Example: 
+" Example:
 "     g:PaperColor_Theme_Options has something like this:
 "       'language': {
 "       \   'python': {
@@ -518,10 +518,10 @@ fun! s:generate_language_option_variables()
   " Part of user-config options
   if has_key(s:options, 'language')
     let l:language_options = s:options['language']
-    " echo l:language_options 
+    " echo l:language_options
     for l:lang in keys(l:language_options)
       let l:options = l:language_options[l:lang]
-      " echo l:lang 
+      " echo l:lang
       " echo l:options
       for l:option in keys(l:options)
         let s:{'langOpt_' . l:lang . '__' . l:option} = l:options[l:option]
@@ -1620,7 +1620,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi jsonNumber' . s:fg_orange
   exec 'hi jsonNull' . s:fg_purple . s:ft_bold
   exec 'hi jsonBoolean' . s:fg_green . s:ft_bold
-  exec 'hi jsonCommentError' . s:fg_pink . s:bg_background 
+  exec 'hi jsonCommentError' . s:fg_pink . s:bg_background
 
   " Go Highlighting
   exec 'hi goDirective' . s:fg_red
@@ -2018,11 +2018,11 @@ fun! s:apply_syntax_highlightings()
   exec 'hi awkSpecialPrintf' . s:fg_olive . s:ft_bold
 
   " Elm highlighting
-  exec 'hi elmImport' . s:fg_navy 
+  exec 'hi elmImport' . s:fg_navy
   exec 'hi elmAlias' . s:fg_aqua
   exec 'hi elmType' . s:fg_pink
   exec 'hi elmOperator' . s:fg_aqua . s:ft_bold
-  exec 'hi elmBraces' . s:fg_aqua . s:ft_bold 
+  exec 'hi elmBraces' . s:fg_aqua . s:ft_bold
   exec 'hi elmTypedef' . s:fg_blue .  s:ft_bold
   exec 'hi elmTopLevelDecl' . s:fg_green . s:ft_bold
 


### PR DESCRIPTION
This pull request adds JSX support, targeting [vim-jsx-pretty](https://github.com/MaxMEllon/vim-jsx-pretty). I've copied the colors used for HTML for the most part, preferring a simple design that doesn't stray too far from this plugin's prior work. I've opted to target vim-jsx-pretty because of its clean design and solid handling of edge cases.

See below for a screenshot:

![image](https://user-images.githubusercontent.com/3723671/53454947-c9efc380-39dd-11e9-8c90-a844ad4385bb.png)

Please let me know if there is any additional information I can provide / show you.