### PR TITLE
Make mkdBlockQuote the same as markdownBlockQuote

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1522,7 +1522,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi mkdLink' . s:fg_blue . s:ft_bold
   exec 'hi mkdURL' . s:fg_comment
   exec 'hi mkdString' . s:fg_foreground
-  exec 'hi mkdBlockQuote' . s:fg_foreground . s:bg_popupmenu_bg
+  exec 'hi mkdBlockQuote' . s:fg_pink
   exec 'hi mkdLinkTitle' . s:fg_pink
   exec 'hi mkdDelimiter' . s:fg_aqua
   exec 'hi mkdRule' . s:fg_pink


### PR DESCRIPTION
`mkdBlockQuote` has a different highlight than `markdownBlockQuote`, this might be intended of course, however the resulting highlight seems hard to read, since both text and background colors are dark.

Unifying the two tags, improves legibility.