### PR TITLE
Add support for Vim 8's g:terminal_ansi_colors

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1103,9 +1103,11 @@ fun! s:set_color_variables()
   let g:terminal_color_15 = color15[0]
 
   " Vim 8's :terminal buffer ANSI colors
-  let g:terminal_ansi_colors = [color00[0], color01[0], color02[0], color03[0],
-      \ color04[0], color05[0], color06[0], color07[0], color08[0], color09[0],
-      \ color10[0], color11[0], color12[0], color13[0], color14[0], color15[0]]
+  if has('terminal')
+    let g:terminal_ansi_colors = [color00[0], color01[0], color02[0], color03[0],
+        \ color04[0], color05[0], color06[0], color07[0], color08[0], color09[0],
+        \ color10[0], color11[0], color12[0], color13[0], color14[0], color15[0]]
+  endif
 
 endfun
 " }}}

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1102,7 +1102,7 @@ fun! s:set_color_variables()
   let g:terminal_color_14 = color14[0]
   let g:terminal_color_15 = color15[0]
 
-  " Vim 8's :terminal buffer ansi colors
+  " Vim 8's :terminal buffer ANSI colors
   let g:terminal_ansi_colors = [color00[0], color01[0], color02[0], color03[0],
       \ color04[0], color05[0], color06[0], color07[0], color08[0], color09[0],
       \ color10[0], color11[0], color12[0], color13[0], color14[0], color15[0]]

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1102,6 +1102,11 @@ fun! s:set_color_variables()
   let g:terminal_color_14 = color14[0]
   let g:terminal_color_15 = color15[0]
 
+  " Vim 8's :terminal buffer ansi colors
+  let g:terminal_ansi_colors = [color00[0], color01[0], color02[0], color03[0],
+      \ color04[0], color05[0], color06[0], color07[0], color08[0], color09[0],
+      \ color10[0], color11[0], color12[0], color13[0], color14[0], color15[0]]
+
 endfun
 " }}}
 


### PR DESCRIPTION
## Context

Similar to what this theme already does for Neovim's terminal buffer support, this PR adds the theme's colors to `g:terminal_ansi_colors`, which tells Vim (version 8 and above) which colors to display for the native `:terminal` buffer.

The code check for the `:terminal` buffer capability before injecting theme's colors.