### PR TITLE
Remove duplicate pythonExClass

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1565,7 +1565,6 @@ fun! s:apply_syntax_highlightings()
   exec 'hi pythonStrFormatting' . s:fg_olive . s:ft_bold
 
   exec 'hi pythonBoolean' . s:fg_green . s:ft_bold
-  exec 'hi pythonExClass' . s:fg_red
   exec 'hi pythonBytesEscape' . s:fg_olive . s:ft_bold
   exec 'hi pythonDottedName' . s:fg_purple
   exec 'hi pythonStrFormat' . s:fg_foreground


### PR DESCRIPTION
The duplicate `pythonExClass` was causing base exception names to be colored the same as try/except/finally clauses, which looked weird

before:
![image](https://user-images.githubusercontent.com/8370058/66710719-464fd080-ed3b-11e9-9178-3282c38d5bc4.png)

after:
![image](https://user-images.githubusercontent.com/8370058/66710723-654e6280-ed3b-11e9-897c-fefa6dbc5db8.png)
