### PR TITLE
Use same colors for import/export-related keywords

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1611,6 +1611,11 @@ fun! s:apply_syntax_highlightings()
   exec 'hi javaScriptMember' . s:fg_foreground
 
   " @target https://github.com/pangloss/vim-javascript
+  exec 'hi jsImport' . s:fg_pink . s:ft_bold
+  exec 'hi jsExport' . s:fg_pink . s:ft_bold
+  exec 'hi jsModuleAs' . s:fg_pink . s:ft_bold
+  exec 'hi jsFrom' . s:fg_pink . s:ft_bold
+  exec 'hi jsExportDefault' . s:fg_pink . s:ft_bold
   exec 'hi jsFuncParens' . s:fg_blue
   exec 'hi jsFuncBraces' . s:fg_blue
   exec 'hi jsParens' . s:fg_blue


### PR DESCRIPTION
This PR extends the integration with https://github.com/pangloss/vim-javascript making all import/export-related keywords to use the same color, just as it's been done with the python syntax integration