### PR TITLE
Typescript Decorator Support

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1609,6 +1609,9 @@ fun! s:apply_syntax_highlightings()
   exec 'hi javaScriptMessage' . s:fg_foreground
   exec 'hi javaScriptMember' . s:fg_foreground
 
+  " TypeScript Highlighting
+  exec 'hi typeScriptDecl' . s:fg_orange
+
   " @target https://github.com/pangloss/vim-javascript
   exec 'hi jsImport' . s:fg_pink . s:ft_bold
   exec 'hi jsExport' . s:fg_pink . s:ft_bold

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1610,7 +1610,8 @@ fun! s:apply_syntax_highlightings()
   exec 'hi javaScriptMember' . s:fg_foreground
 
   " TypeScript Highlighting
-  exec 'hi typeScriptDecl' . s:fg_orange
+  exec 'hi typescriptDecorators' . s:fg_orange
+  exec 'hi typescriptLabel' . s:fg_purple . s:ft_bold
 
   " @target https://github.com/pangloss/vim-javascript
   exec 'hi jsImport' . s:fg_pink . s:ft_bold


### PR DESCRIPTION
Color scheme did not apply for Typescript Decorator.

How about use orange like this?

This minimal PR is only for decorator and 'default, async' keyword.

We hope that more formal Typescript support will be comming.

Best regards.