### PR TITLE
chore: add a note about the airline theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ To set [vim-airline](https://github.com/bling/vim-airline) theme:
 
     let g:airline_theme='papercolor'
 
+Note: to be able to use this theme, it is also necessary to install [vim-airline-themes](https://github.com/vim-airline/vim-airline-themes)
+
 To set [lightline](https://github.com/itchyny/lightline.vim) theme:
 
     let g:lightline = { 'colorscheme': 'PaperColor' }


### PR DESCRIPTION
This PR will add a note about the papercolor airline theme, which warns that one won't be able to use it without installing [vim-airline-themes](https://github.com/vim-airline/vim-airline-themes), since the themes from [vim-airline](https://github.com/bling/vim-airline) were removed from the "main" repo.