### PR TITLE
Added improved version for konsole to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Suggestions/Wishes/Questions/Comments are welcome via [Github issues](https://gi
 
 [PaperColor Light for konsole](https://raw.githubusercontent.com/z2oh/dotfiles/82bf6835948674f0ed1f98a14b82975ff2dd8f3e/konsole/paperrlight.colorscheme) by [z2oh](https://github.com/z2oh)
 
+[PaperColor Light for konsole](https://github.com/MaxG87/konsole-papercolor) (some palette collisions resolved) by [MaxG87](https://github.com/MaxG87)
+
 [PaperColor Theme for Vis Editor](https://github.com/jceb/dotfiles/blob/master/config/vis/lexers/themes/papercolor.lua) by Jan Christoph Ebersbach
 
 [Airline PaperColor Theme for Emacs Powerline](https://github.com/AnthonyDiGirolamo/airline-themes) by Anthony DiGirolamo


### PR DESCRIPTION
This fork of the theme for KDE konsole resolves some palette collisions. E.g. zsh autosuggestions can now be distinguished visually from normal text.