### PR TITLE
Add support for vim-signify

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently designed for these languages:
 
 Other file types can still display well as long as your Vim is set up to recognize the language syntax even though that may not be the optimal experience. So, if the language you are working on isn't listed here, feel free to make a design request.
 
-Plugin support: vimdiff, netrw, [NERDTree](https://github.com/scrooloose/nerdtree), [tagbar](https://github.com/majutsushi/tagbar), [tabline](https://github.com/mkitt/tabline.vim), [vim-airline](https://github.com/bling/vim-airline), [vim-indent-guides](https://github.com/nathanaelkane/vim-indent-guides), [vim-startify](https://github.com/mhinz/vim-startify), [Agit](https://github.com/cohama/agit.vim)
+Plugin support: vimdiff, netrw, [NERDTree](https://github.com/scrooloose/nerdtree), [tagbar](https://github.com/majutsushi/tagbar), [tabline](https://github.com/mkitt/tabline.vim), [vim-airline](https://github.com/bling/vim-airline), [vim-indent-guides](https://github.com/nathanaelkane/vim-indent-guides), [vim-startify](https://github.com/mhinz/vim-startify), [Agit](https://github.com/cohama/agit.vim), [vim-signify](https://github.com/mhinz/vim-signify)
 
 (see below for syntax-highlighting plugins target)
 

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -2178,6 +2178,14 @@ fun! s:apply_syntax_highlightings()
   exec 'hi StartifyBracket' . s:fg_aqua
   exec 'hi StartifySpecial' . s:fg_aqua
 
+  " Plugin: Signify
+  exec 'hi SignifyLineChange' . s:fg_diffchange_fg
+  exec 'hi SignifySignChange' . s:fg_diffchange_fg
+  exec 'hi SignifyLineAdd' . s:fg_diffadd_fg
+  exec 'hi SignifySignAdd' . s:fg_diffadd_fg
+  exec 'hi SignifyLineDelete' . s:fg_diffdelete_fg
+  exec 'hi SignifySignDelete' . s:fg_diffdelete_fg
+
   " Git commit message
   exec 'hi gitcommitSummary' . s:fg_blue
   exec 'hi gitcommitHeader' . s:fg_green . s:ft_bold


### PR DESCRIPTION
This PR adds support for [vim-signify](https://github.com/mhinz/vim-signify) plugin. Basically it just sets signify sign colors to diff foreground colors with no background. The result looks like this:
![image](https://user-images.githubusercontent.com/62112140/97094896-5d254480-166a-11eb-83cf-8cf88e1cb669.png)
