### PR TITLE
Change Type from pink to positive

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1222,7 +1222,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi Macro' . s:fg_blue
   exec 'hi PreCondit' . s:fg_aqua
 
-  exec 'hi Type' . s:fg_pink . s:ft_bold
+  exec 'hi Type' . s:fg_positive . s:ft_bold
   exec 'hi StorageClass' . s:fg_navy . s:ft_bold
   exec 'hi Structure' . s:fg_blue . s:ft_bold
   exec 'hi Typedef' . s:fg_pink . s:ft_bold


### PR DESCRIPTION
Currently `Type` is a bold bright pink. I found the combination of bold and bright pink distracting. Also it seems `Statement` is the same color without the bold, so oftentimes you get bright pink next to bright pink.

I left the bold and changed to a dark green instead.