### PR TITLE
Add link to additional papercolor theme for vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,8 @@ I try to respond to users' feedback and feature requests as much as possible. Ob
 
 [PaperColor for Vscode](https://github.com/Rozbo/papercolor-vscode) by [rozbo](https://github.com/rozbo)
 
+[PaperColor for Vscode Redux](https://github.com/mrworkman/papercolor-vscode-redux) by [mrworkman](https://github.com/mrworkman)
+
 [PaperColor theme for Hyper](https://github.com/rafaelrinaldi/hyper-papercolor) by [Rafael Rinaldi](https://github.com/rafaelrinaldi)
 
 [PaperColor Theme for kitty](https://github.com/craffate/papercolor-kitty) by [Cyril Raffatelli](https://github.com/craffate)


### PR DESCRIPTION
I am not the author of this theme, but think it would be useful to make it more visible in addition to the papercolor theme for vscode by rozbo.