### PR TITLE
fix: correct link to papercolor light contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ I try to respond to users' feedback and feature requests as much as possible. Ob
 
 [PaperColor Theme for kitty](https://github.com/craffate/papercolor-kitty) by [Cyril Raffatelli](https://github.com/craffate)
 
-[PaperColor Light theme for several tools](https://gitlab.com/dev-ninjas-org/papercolor-light-contrib) by [ch1r0x](https://gitlab.com/ch1r0x)
+[PaperColor Light theme for several tools](https://github.com/stoerdebegga/papercolor-light-contrib) by [stoerdebegga](https://github.com/stoerdebegga)
 
 [PaperColor Light theme for Alacritty](https://github.com/eendroroy/alacritty-theme/blob/master/themes/papercolor_light.yaml)
 


### PR DESCRIPTION
As mentioned I shuffled around repositories, services and usernames.. thus a brand new PR which fully reflects those changes. Furthermore I've ensured it's a public repository.. not like last time. Apologies for the extra work.