### PR TITLE
Highlight Neovim (LSP) diagnostics

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1254,6 +1254,16 @@ fun! s:apply_syntax_highlightings()
     exec 'hi LspDiagnosticsUnderlineWarning cterm=undercurl gui=undercurl' . s:sp_todo_fg
     exec 'hi LspDiagnosticsUnderlineInformation cterm=undercurl gui=undercurl' . s:sp_todo_fg
     exec 'hi LspDiagnosticsUnderlineHint cterm=undercurl gui=undercurl' . s:sp_todo_fg
+
+    hi! link DiagnosticError LspDiagnosticsDefaultError
+    hi! link DiagnosticWarn LspDiagnosticsDefaultWarning
+    hi! link DiagnosticInfo LspDiagnosticsDefaultInformation
+    hi! link DiagnosticHint LspDiagnosticsDefaultHint
+
+    hi! link DiagnosticUnderlineError LspDiagnosticsUnderlineError
+    hi! link DiagnosticUnderlineWarn LspDiagnosticsUnderlineWarning
+    hi! link DiagnosticUnderlineInfo LspDiagnosticsUnderlineInformation
+    hi! link DiagnosticUnderlineHint LspDiagnosticsUnderlineHint
   endif
 
   " Extension {{{


### PR DESCRIPTION
Adding highlight groups for Neovim 0.5+ LSP client's diagnostics. Colours were taken from the CoC highlight groups.

The first set of highlights is used in Neovim 0.5.x, while the linked ones are the renamed groups in 0.6 (HEAD).

I'm using fancier undercurls instead of underlines which are used to denote the location of a diagnostic. Terminals that don't support this, fall back to underlines.

![Screenshot_20211010_105238](https://user-images.githubusercontent.com/214730/136689146-316b42e6-6197-4b85-9bda-5ed0d1b3e173.png)
