### PR TITLE
feat: Add support for plugin hrsh7th/nvim-cmp

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -2277,6 +2277,25 @@ fun! s:apply_syntax_highlightings()
     exec 'hi DapUIFloatBorder' . s:fg_blue
   endif
 
+  " Plugin: hrsh7th/nvim-cmp
+  if has('nvim')
+    hi! link CmpItemKindValue Number
+    hi! link CmpItemKindVariable Identifier
+    hi! link CmpItemKindKeyword Keyword
+    hi! link CmpItemKindField CmpItemKindVariable
+    exec 'hi CmpItemKindFunction' . s:fg_blue
+    hi! link CmpItemKindMethod CmpItemKindFunction
+    hi! link CmpItemKindConstructor CmpItemKindFunction
+    hi! link CmpItemKindClass Structure
+    hi! link CmpItemKindInterface Structure
+    exec 'hi CmpItemKindSnippet' . s:fg_orange
+    exec 'hi CmpItemKindFile' . s:fg_orange
+    hi! link CmpItemKindFolder CmpItemKindFile
+    exec 'hi CmpItemAbbrMatch' . s:fg_blue . s:ft_bold
+    exec 'hi CmpItemAbbrMatchFuzzy' . s:fg_blue . s:ft_bold
+    exec 'hi CmpItemAbbrDeprecated' . s:fg_foreground . ' gui=strikethrough'
+  endif
+
 endfun
 " }}}
 


### PR DESCRIPTION
I added support for the completion plugin [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).

Some screenshots:

* Light theme:
  * Before:
![nvim-cmp-light-before](https://user-images.githubusercontent.com/49882031/159255219-aa4d60f3-ad34-4cd9-91a3-2b60d42d7fd8.png)
  * After:
![nvim-cmp-light-after](https://user-images.githubusercontent.com/49882031/159255241-cadea5bd-6849-4aa4-b1aa-b903024a9c08.png)
* Dark theme:
  * Before:
![nvim-cmp-dark-before](https://user-images.githubusercontent.com/49882031/159255314-d06edd7c-5661-4b1d-958c-d82289ed0154.png)
  * After:
![nvim-cmp-dark-after](https://user-images.githubusercontent.com/49882031/159255332-2acee108-670a-4021-aa05-25e6dc025b73.png)

* Another screenshot:
![bonus1](https://user-images.githubusercontent.com/49882031/159255710-d85a34e7-321a-4153-a405-81addcde004f.png)

