### PR TITLE
Add haskell no_bold_types option

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ An example configuration is available below
 ```VimL
 let g:PaperColor_Theme_Options = {
   \   'language': {
+  \     'haskell': {
+  \       'no_bold_types' : 1
+  \     },
   \     'python': {
   \       'highlight_builtins' : 1
   \     },
@@ -295,11 +298,12 @@ let g:PaperColor_Theme_Options = {
 
 #### Currently available language options
 
-language | option                       | value     | default
-------   | ------                       | ------    | ------
-`c`      | `highlight_builtins`         | 1: enable | 0: disable
-`cpp`    | `highlight_standard_library` | 1: enable | 0: disable
-`python` | `highlight_builtins`         | 1: enable | 0: disable
+language  | option                       | value     | default
+------    | ------                       | ------    | ------
+`c`       | `highlight_builtins`         | 1: enable | 0: disable
+`cpp`     | `highlight_standard_library` | 1: enable | 0: disable
+`python`  | `highlight_builtins`         | 1: enable | 0: disable
+`haskell` | `no_bold_types`              | 1: enable | 0: disable
 
 
 ### Vim-airline support

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -507,7 +507,8 @@ fun! s:generate_language_option_variables()
   let l:available_language_options = [
         \   'c__highlight_builtins',
         \   'cpp__highlight_standard_library',
-        \   'python__highlight_builtins'
+        \   'python__highlight_builtins',
+        \   'haskell__no_bold_types'
         \ ]
 
   " 1. Generate variables and set to default value
@@ -1739,7 +1740,11 @@ fun! s:apply_syntax_highlightings()
 
 
   " Haskell Highlighting
-  exec 'hi haskellType' . s:fg_aqua . s:ft_bold
+  if s:langOpt_haskell__no_bold_types == 1
+    exec 'hi haskellType' . s:fg_aqua
+  else 
+    exec 'hi haskellType' . s:fg_aqua . s:ft_bold
+  endif
   exec 'hi haskellIdentifier' . s:fg_orange . s:ft_bold
   exec 'hi haskellOperators' . s:fg_pink
   exec 'hi haskellWhere' . s:fg_foreground . s:ft_bold


### PR DESCRIPTION
Add Haskell language option that disables bold for types and constructors.  

![image](https://github.com/NLKNguyen/papercolor-theme/assets/7745032/06c34a0e-9a39-48ef-917d-e2d5e3a00e1d)
