### PR TITLE
Add IncSearch colour

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -65,6 +65,8 @@ fun! s:register_default_theme()
         \       'popupmenu_bg' : ['#d0d0d0', '252'],
         \       'search_fg' : ['#444444', '238'],
         \       'search_bg' : ['#ffff5f', '227'],
+        \       'incsearch_fg' : ['#ffff5f', '227'],
+        \       'incsearch_bg' : ['#444444', '238'],
         \       'linenumber_fg' : ['#b2b2b2', '249'],
         \       'linenumber_bg' : ['#eeeeee', '255'],
         \       'vertsplit_fg' : ['#005f87', '24'],
@@ -155,6 +157,8 @@ fun! s:register_default_theme()
         \       'popupmenu_bg' : ['#303030', '236'],
         \       'search_fg' : ['#000000', '16'],
         \       'search_bg' : ['#00875f', '29'],
+        \       'incsearch_fg' : ['#00875f', '29'],
+        \       'incsearch_bg' : ['#000000', '16'],
         \       'linenumber_fg' : ['#585858', '240'],
         \       'linenumber_bg' : ['#1c1c1c', '234'],
         \       'vertsplit_fg' : ['#5f8787', '66'],
@@ -1027,6 +1031,10 @@ fun! s:set_color_variables()
   call s:create_color_variables('search_fg', get(s:palette, 'search_fg', color00) , 'Black')
   call s:create_color_variables('search_bg', get(s:palette, 'search_bg', color15) , 'Yellow')
 
+  " IncSearch: ex: during a search
+  call s:create_color_variables('incsearch_fg', get(s:palette, 'incsearch_fg', color00) , 'Black')
+  call s:create_color_variables('incsearch_bg', get(s:palette, 'incsearch_bg', color15) , 'Yellow')
+
   " Todo: ex: TODO
   call s:create_color_variables('todo_fg', get(s:palette, 'todo_fg', color05) , 'LightYellow')
   call s:create_color_variables('todo_bg', get(s:palette, 'todo_bg', color00) , 'Black')
@@ -1155,6 +1163,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi Cursor' . s:fg_cursor_fg . s:bg_cursor_bg
   exec 'hi SpecialKey' . s:fg_nontext
   exec 'hi Search' . s:fg_search_fg . s:bg_search_bg
+  exec 'hi IncSearch' . s:fg_incsearch_fg . s:bg_incsearch_bg
   exec 'hi StatusLine' . s:fg_statusline_active_bg . s:bg_statusline_active_fg
   exec 'hi StatusLineNC' . s:fg_statusline_inactive_bg . s:bg_statusline_inactive_fg
   exec 'hi StatusLineTerm' . s:fg_statusline_active_bg . s:bg_statusline_active_fg


### PR DESCRIPTION
This adds a colour for `IncSearch`, shown if `'incsearch'` is on, or more crucially, to distinguish the current match when confirming substitutions (`:s/.../.../c`).