### PR TITLE
Error underlines and helpfile tweaks

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -817,14 +817,14 @@ fun! s:set_format_attributes()
     let s:ft_reverse = " cterm=reverse gui=reverse "
     let s:ft_italic  = " cterm=italic gui=italic "
     let s:ft_italic_bold = " cterm=italic,bold gui=italic,bold "
-    let s:ft_undercurl = " gui=undercurl "
+    let s:ft_undercurl = " cterm=underline gui=undercurl "
   elseif s:mode == s:MODE_256_COLOR
     let s:ft_bold    = " cterm=bold "
     let s:ft_none    = " cterm=none "
     let s:ft_reverse = " cterm=reverse "
     let s:ft_italic  = " cterm=italic "
     let s:ft_italic_bold = " cterm=italic,bold "
-    let s:ft_undercurl = ""
+    let s:ft_undercurl = " cterm=underline "
   else
     let s:ft_bold    = ""
     let s:ft_none    = " cterm=none "
@@ -921,13 +921,21 @@ fun! s:set_color_variables()
     fun! s:create_color_variables(color_name, rich_color, term_color)
       let {'s:fg_' . a:color_name} = ' ctermfg=' . a:rich_color[1] . ' '
       let {'s:bg_' . a:color_name} = ' ctermbg=' . a:rich_color[1] . ' '
-      let {'s:sp_' . a:color_name} = ''
+      if has('patch-8.2.863')
+          let {'s:sp_' . a:color_name} = ' ctermul=' . a:rich_color[1] . ' '
+      else
+          let {'s:sp_' . a:color_name} = ' '
+      endif
     endfun
   else
     fun! s:create_color_variables(color_name, rich_color, term_color)
       let {'s:fg_' . a:color_name} = ' ctermfg=' . a:term_color . ' '
       let {'s:bg_' . a:color_name} = ' ctermbg=' . a:term_color . ' '
-      let {'s:sp_' . a:color_name} = ''
+      if has('patch-8.2.863')
+          let {'s:sp_' . a:color_name} = ' ctermul=' . a:term_color . ' '
+      else
+          let {'s:sp_' . a:color_name} = ' '
+      endif
     endfun
   endif
   " }}}

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1185,7 +1185,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi ModeMsg' . s:fg_olive
   exec 'hi MoreMsg' . s:fg_olive
   exec 'hi Question' . s:fg_olive
-  exec 'hi WarningMsg' . s:fg_pink . s:ft_undercurl
+  exec 'hi WarningMsg' . s:fg_pink
   exec 'hi MatchParen' . s:fg_matchparen_fg . s:bg_matchparen_bg
   exec 'hi Folded' . s:fg_folded_fg . s:bg_folded_bg
   exec 'hi WildMenu' . s:fg_wildmenu_fg . s:bg_wildmenu_bg . s:ft_bold
@@ -1258,7 +1258,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi SpecialComment' . s:fg_comment . s:ft_bold
   exec 'hi Debug' . s:fg_orange
 
-  exec 'hi Error' . s:fg_error_fg . s:bg_error_bg . s:ft_undercurl . s:sp_red
+  exec 'hi Error' . s:fg_error_fg . s:bg_error_bg
   exec 'hi Todo' . s:fg_todo_fg . s:bg_todo_bg . s:ft_bold
 
   exec 'hi Title' . s:fg_comment

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -2182,6 +2182,10 @@ fun! s:apply_syntax_highlightings()
   exec 'hi NERDTreeOpenable' . s:fg_aqua . s:ft_bold
   exec 'hi NERDTreeClosable' . s:fg_pink
 
+  " Plugin: vim-fern-git-status
+  exec 'hi FernGitStatusUnmerged' . s:fg_error_fg . s:bg_error_bg
+  exec 'hi FernGitStatusWorktree' . s:fg_pink
+
   " Plugin: Tagbar
   exec 'hi TagbarHelpTitle' . s:fg_blue . s:ft_bold
   exec 'hi TagbarHelp' . s:fg_foreground

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1185,7 +1185,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi ModeMsg' . s:fg_olive
   exec 'hi MoreMsg' . s:fg_olive
   exec 'hi Question' . s:fg_olive
-  exec 'hi WarningMsg' . s:fg_pink
+  exec 'hi WarningMsg' . s:fg_pink . s:ft_undercurl
   exec 'hi MatchParen' . s:fg_matchparen_fg . s:bg_matchparen_bg
   exec 'hi Folded' . s:fg_folded_fg . s:bg_folded_bg
   exec 'hi WildMenu' . s:fg_wildmenu_fg . s:bg_wildmenu_bg . s:ft_bold
@@ -1324,9 +1324,11 @@ fun! s:apply_syntax_highlightings()
   exec 'hi vimHiGroup' . s:fg_foreground
   exec 'hi vimGroup' . s:fg_navy . s:ft_bold
   exec 'hi vimOnlyOption' . s:fg_blue
+
   " Helpfile
-  exec 'hi HelpStar' . s:fg_blue . s:ft_bold
-  exec 'hi HelpBar' . s:fg_blue . s:ft_bold
+  exec 'hi link helpStar Operator'
+  exec 'hi link helpBar Operator'
+  exec 'hi link helpBacktick Operator'
 
   " Makefile Highlighting
   exec 'hi makeIdent' . s:fg_blue
@@ -2275,7 +2277,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi CocHintFloat' . s:fg_popupmenu_fg . s:bg_popupmenu_bg . s:ft_none
 
   exec 'hi CocErrorHighlight' . s:fg_foreground . s:bg_spellbad . s:ft_undercurl . s:sp_red
-  exec 'hi CocWarningHighlight' . s:fg_foreground . s:bg_spellcap
+  exec 'hi CocWarningHighlight' . s:fg_foreground . s:bg_spellcap . s:ft_undercurl
   exec 'hi CocInfoHighlight' . s:fg_foreground . s:bg_spellcap
   exec 'hi CocHintHighlight' . s:fg_foreground . s:bg_spellcap
 

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1326,9 +1326,10 @@ fun! s:apply_syntax_highlightings()
   exec 'hi vimOnlyOption' . s:fg_blue
 
   " Helpfile
-  exec 'hi link helpStar Operator'
-  exec 'hi link helpBar Operator'
-  exec 'hi link helpBacktick Operator'
+  exec 'hi link helpIgnore Typedef'
+  exec 'hi link helpStar Typedef'
+  exec 'hi link helpBar Typedef'
+  exec 'hi link helpBacktick Typedef'
 
   " Makefile Highlighting
   exec 'hi makeIdent' . s:fg_blue

--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -817,18 +817,21 @@ fun! s:set_format_attributes()
     let s:ft_reverse = " cterm=reverse gui=reverse "
     let s:ft_italic  = " cterm=italic gui=italic "
     let s:ft_italic_bold = " cterm=italic,bold gui=italic,bold "
+    let s:ft_undercurl = " gui=undercurl "
   elseif s:mode == s:MODE_256_COLOR
     let s:ft_bold    = " cterm=bold "
     let s:ft_none    = " cterm=none "
     let s:ft_reverse = " cterm=reverse "
     let s:ft_italic  = " cterm=italic "
     let s:ft_italic_bold = " cterm=italic,bold "
+    let s:ft_undercurl = ""
   else
     let s:ft_bold    = ""
     let s:ft_none    = " cterm=none "
     let s:ft_reverse = " cterm=reverse "
     let s:ft_italic  = ""
     let s:ft_italic_bold = ""
+    let s:ft_undercurl = ""
   endif
 
   " Unless instructed otherwise either by theme setting or user overriding
@@ -1247,7 +1250,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi SpecialComment' . s:fg_comment . s:ft_bold
   exec 'hi Debug' . s:fg_orange
 
-  exec 'hi Error' . s:fg_error_fg . s:bg_error_bg
+  exec 'hi Error' . s:fg_error_fg . s:bg_error_bg . s:ft_undercurl . s:sp_red
   exec 'hi Todo' . s:fg_todo_fg . s:bg_todo_bg . s:ft_bold
 
   exec 'hi Title' . s:fg_comment
@@ -1313,6 +1316,9 @@ fun! s:apply_syntax_highlightings()
   exec 'hi vimHiGroup' . s:fg_foreground
   exec 'hi vimGroup' . s:fg_navy . s:ft_bold
   exec 'hi vimOnlyOption' . s:fg_blue
+  " Helpfile
+  exec 'hi HelpStar' . s:fg_blue . s:ft_bold
+  exec 'hi HelpBar' . s:fg_blue . s:ft_bold
 
   " Makefile Highlighting
   exec 'hi makeIdent' . s:fg_blue
@@ -2260,7 +2266,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi CocInfoFloat' . s:fg_popupmenu_fg . s:bg_popupmenu_bg . s:ft_none
   exec 'hi CocHintFloat' . s:fg_popupmenu_fg . s:bg_popupmenu_bg . s:ft_none
 
-  exec 'hi CocErrorHighlight' . s:fg_foreground . s:bg_spellbad
+  exec 'hi CocErrorHighlight' . s:fg_foreground . s:bg_spellbad . s:ft_undercurl . s:sp_red
   exec 'hi CocWarningHighlight' . s:fg_foreground . s:bg_spellcap
   exec 'hi CocInfoHighlight' . s:fg_foreground . s:bg_spellcap
   exec 'hi CocHintHighlight' . s:fg_foreground . s:bg_spellcap


### PR DESCRIPTION
## TL;DR:
* ctermul support, in compatible versions of Vim
	* Nvim is not handled because I don't use it and don't feel like looking up what nvim does, and how to test for it
* Underlines in coc.nvim errors and warnings, using a newly added `s:ft_undercurl`
* Specific helpfile highlight groups (as per #161 that I closed for some reason I don't remember) default-linking to `Ignore` now highlight properly. This is only relevant for helpfile writers, and makes no change for helpfile readers.

## Changes
### Underlines

One of the problems with most of the current error highlighting is that it disappears when that line is active, at least with `set cursorline`. 
This screenshot demonstrates the current solution:


![Pasted image 20240611002436](https://github.com/NLKNguyen/papercolor-theme/assets/29489988/15a10ae7-3acd-4764-b7d4-53ddfe705ebd)


(Note that the cursor colour is not the default for papercolour; that change is in my vimrc, and not part of this PR)

Note that the behaviour of the background for both warning and error has not changed; without the underline, it's impossible to tell where the error is in a line without first leaving the line. This is annoying while writing code with an LSP

Note that the warning underline being black is not fully intentional, but I couldn't find a colour that worked well with yellow. Using the same colour as the background colour makes the underline have far too little contrast - same with the error undercurl, but `s:fg_red` exists, so that's a non-issue.

#### Terminal caveats

In terminal vim, `cterm=underline` is used instead of `undercurl`. This is an intentional decision because, for reasons I don't fully understand, setting `cterm=undercurl` results in no underline of any kind in gnome terminal. Same with ignoring `cterm` fully and only setting `gui`. According to the docs, `undercurl` is supposed to fall back to underline when `undercurl` isn't available, but I was unable to get this to work within a few minutes, so I didn't bother looking deeper into it. I assume I'm missing something obvious, but I'm leaving this as an exercise for someone else with the patience to figure it out. In either case, the error visibility problem is still fixed even though the type of underline isn't quite right.

Non-GUI and non-256 terminals have also not been handled, and instead gets a blank `s:ft_undercurl`. I'm not sure whether or not it supports `cterm=underline` at all, and I'd rather not break anything.

#### Affected groups

Only coc.nvim's highlight groups have been given underlines. The Error and WarningMsg groups have such wide-spread use elsewhere that underlining them causes multiple theming problems. With `s:ft_undercurl`, it's easier to add underlines where it makes sense rather than doing the opposite, and removing them from anywhere that didn't expect them.

### Ctermul support (... in Vim)

`guisp` was already implemented, but the equivalent cterm command was left blank. At the time, no alternatives existed. As of Vim [8.2.0863](https://github.com/vim/vim/commit/e023e88bed3f2e0a7ea4cf10cac2de80bc9c271c), `ctermul` exists. This PR adds support for it, with a conditional enable for compatibility using `has`. This also means ctermul isn't enabled for nvim, which I won't be doing in this PR anyway, because I don't use nvim and I have no clue if it has it, much less how to check if it's present in the current version.

### helpBar, helpStar, helpBacktick, and helpIgnore

This change is primarily aimed at anyone writing help documents. Prior to this change (as per #161), these characters were fully hidden. While that is irrelevant for anyone reading help documents, if you write them, it's *incredibly* annoying to work with nearly invisible characters. 

After this change, helpStar, helpBar, and helpBacktick, as well as helpIgnore for the `Headers~` and `><` blocks are actually visible. For some reason, I couldn't find dedicated syntax highlight groups for `~` and `><` - they seem to just be part of `helpIgnore`, which is why `helpIgnore` has been highlighted. I've been unable to find any unintentional consequences of this so far.

![Pasted image 20240611005349](https://github.com/NLKNguyen/papercolor-theme/assets/29489988/95f47eed-7b43-4a7c-83de-afcdb68fbf11)


Note that this screenshot was taken with `conceallevel=0` for screenshot reasons. They're still otherwise hidden for anyone reading the helpfile. IIRC, helpfiles have conceallevel set to something non-zero by default, at least when using the `:help` command[^1], so this change is only visible when editing helpfiles. This is also when it's useful to have these characters visible.

[^1]: In addition to conceallevel, concealcursor appears to be reset to `nc` inside a help document opened with `:help`, so I'm pretty sure this won't be visible to anyone reading help files.
[^2]: I'm not entirely clear on where ErrorMsg is used, but I've been unable to find any use of it in normal buffers, so I assume it doesn't appear in normal buffers. If I'm wrong, it's an easy fix Later:tm:, or in a quick patch before this PR is merged