### PR TITLE
Add CurSearch colours

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1165,6 +1165,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi SpecialKey' . s:fg_nontext
   exec 'hi Search' . s:fg_search_fg . s:bg_search_bg
   exec 'hi IncSearch' . s:fg_incsearch_fg . s:bg_incsearch_bg
+  exec 'hi! link CurSearch Search'
   exec 'hi StatusLine' . s:fg_statusline_active_bg . s:bg_statusline_active_fg
   exec 'hi StatusLineNC' . s:fg_statusline_inactive_bg . s:bg_statusline_inactive_fg
   exec 'hi StatusLineTerm' . s:fg_statusline_active_bg . s:bg_statusline_active_fg


### PR DESCRIPTION
This adds support for `CurSearch`, added in vim commit [a43993897aa3 / 8.2.4724](https://github.com/vim/vim/commit/a43993897aa372159f682df37562f159994dc85c/) - without this the default is not adjusted