### PR TITLE
fix function color

### DIFF
--- a/colors/PaperColor.vim
+++ b/colors/PaperColor.vim
@@ -1219,7 +1219,7 @@ fun! s:apply_syntax_highlightings()
   exec 'hi Float' . s:fg_orange
 
   exec 'hi Identifier' . s:fg_navy
-  exec 'hi Function' . s:fg_foreground
+  exec 'hi Function' . s:fg_blue
 
   exec 'hi Statement' . s:fg_pink . s:ft_none
   exec 'hi Conditional' . s:fg_purple . s:ft_bold


### PR DESCRIPTION
[As pointed out in the conversation](https://github.com/NLKNguyen/papercolor-theme/issues/154#issuecomment-819015933) of [issue 154](https://github.com/NLKNguyen/papercolor-theme/issues/154) highlighting of functions did not work because "no" color was set. 

This PR replaces foreground by blue. I have no strong feelings about blue but some color should be set.

Btw, thanks for this nice color theme!